### PR TITLE
fix version file path

### DIFF
--- a/sprockets-es6.gemspec
+++ b/sprockets-es6.gemspec
@@ -1,3 +1,5 @@
+$:.push File.expand_path("../lib", __FILE__)
+
 require 'sprockets/es6/version'
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Requiring a relative file path was removed in Ruby 1.9