### PR TITLE
Add version.rb to gemspec files

### DIFF
--- a/sprockets-es6.gemspec
+++ b/sprockets-es6.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = [
     'lib/sprockets/es6.rb',
+    'lib/sprockets/es6/version.rb',
     'LICENSE',
     'README.md'
   ]


### PR DESCRIPTION
When calling `require "sprockets/es6"` you get the following error:
`LoadError: cannot load such file -- sprockets/es6/version` because the
version isn't being packaged with the gem.