### PR TITLE
Switch to new charset detector shorthand

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -33,7 +33,7 @@ module Sprockets
   end
 
   append_path ES6to5::Source.root
-  register_mime_type 'text/ecmascript-6', extensions: ['.es6'], charset: EncodingUtils::DETECT_UNICODE
+  register_mime_type 'text/ecmascript-6', extensions: ['.es6'], charset: :unicode
   register_transformer 'text/ecmascript-6', 'application/javascript', ES6
   register_preprocessor 'text/ecmascript-6', DirectiveProcessor
 end


### PR DESCRIPTION
In beta7 https://github.com/sstephenson/sprockets/commit/9c01b7e6747904cbac9dc6a0e32b912dcf8f15c6 changed the way charsets are declared, this brings us inline with that change.