### PR TITLE
Set filename options for ES6to5.transform

### DIFF
--- a/lib/sprockets/es6.rb
+++ b/lib/sprockets/es6.rb
@@ -26,7 +26,10 @@ module Sprockets
     def call(input)
       data = input[:data]
       result = input[:cache].fetch(@cache_key + [data]) do
-        ES6to5.transform(data, @options)
+        ES6to5.transform(data, @options.merge(
+          'filename' => input[:filename],
+          'filenameRelative' => input[:name] + '.js',
+        ))
       end
       result['code']
     end


### PR DESCRIPTION
* `filename` is required to show the proper filename on syntax errors
* `filenameRelative` is used to build module ids (names)

Without these options all files / modules will be named "unknown".

**Example:**
filename: '/app/assets/foo/bar/baz.es6.erb'
filenameRelative: 'foo/bar/baz.js'
moduleId: 'foo/bar/baz'

Setting these options is required to properly transpile ES6 modules as discussed in issue #6.