### PR TITLE
Update README Sprockets Version Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ in Sprockets 4.x.
 
 ## Caveats
 
-Requires Sprockets 3 betas.
+Requires Sprockets 3 release candidate series or newer.
 
 ``` ruby
-gem 'sprockets', '~>3.0.0.beta'
+gem 'sprockets', '~>3.0.0.rc'
 ```
 
 ### Requires asset manifests for precompiling


### PR DESCRIPTION
...from beta series to release candidate series.

RC1 was released 3 days ago March 29th: https://rubygems.org/gems/sprockets

Should make people even more comfortable using the project. (I'm about to start using it for the team at https://gainfitness.com)